### PR TITLE
Proper fix for seed meta mismatch

### DIFF
--- a/src/main/java/fluxedCrystals/config/ConfigHandler.java
+++ b/src/main/java/fluxedCrystals/config/ConfigHandler.java
@@ -87,14 +87,13 @@ public class ConfigHandler extends AbstractConfigHandler {
 		}
 
 		Collections.sort(cropFiles, new Comparator()
-            {
-                 public int compare(final Object o1, final Object o2)
-                 {
-                     return new String(((File)o1).getName()).compareTo(new String(((File) o2).getName()));
-                 }
-
-            }
-        );
+                    {
+                        public int compare(final Object o1, final Object o2)
+                        {
+                            return new String(((File)o1).getName()).compareTo(new String(((File) o2).getName()));
+                        }
+                    }
+                );
 
 		JsonConfigReader<SeedType> cropReader;
 		List<SeedCrystalRecipe> recipes = RecipeRegistry.getSeedCropRecipes();

--- a/src/main/java/fluxedCrystals/config/ConfigHandler.java
+++ b/src/main/java/fluxedCrystals/config/ConfigHandler.java
@@ -5,6 +5,7 @@ import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import net.minecraft.block.Block;
@@ -84,7 +85,17 @@ public class ConfigHandler extends AbstractConfigHandler {
 				TTFileUtils.copyFromJar(FluxedCrystals.class, ModProps.modid + "/misc/" + "enderioCrystal.json", enderioCrops);
 			}
 		}
-		Collections.sort(cropFiles);
+
+		Collections.sort(cropFiles, new Comparator()
+            {
+                 public int compare(final Object o1, final Object o2)
+                 {
+                     return new String(((File)o1).getName()).compareTo(new String(((File) o2).getName()));
+                 }
+
+            }
+        );
+
 		JsonConfigReader<SeedType> cropReader;
 		List<SeedCrystalRecipe> recipes = RecipeRegistry.getSeedCropRecipes();
 		for (int i = 0; i < cropFiles.size(); i++) {


### PR DESCRIPTION
So, the bug in question happens if server and client OSes have different ideas for how the file names should be sorted. Original attempt to fix this was
```
Collections.sort(cropFiles);
```
which does... exactly nothing. Why? Because it uses [`compareTo` method of class `File`](http://docs.oracle.com/javase/7/docs/api/java/io/File.html#compareTo%28java.io.File%29):

> *The ordering defined by this method depends upon the underlying system*. On UNIX systems, alphabetic case is significant in comparing pathnames; on Microsoft Windows systems it is not.

My fix forces the `Collections.sort` to use `String.compareTo`, which is case-sensitive on all OSes.